### PR TITLE
Updates in sfp template for chapters "indien van toepassing"

### DIFF
--- a/inst/rmarkdown/templates/template_sfp_nl/skeleton/01_afhankelijkheden.Rmd
+++ b/inst/rmarkdown/templates/template_sfp_nl/skeleton/01_afhankelijkheden.Rmd
@@ -1,6 +1,7 @@
-# Afhankelijkheden (Indien van toepassing)
+# Afhankelijkheden
 
 <!--
+Alleen in te vullen indien van toepassing.
 Protocols waarnaar in dit protocol verwezen wordt: bv SIP_xxx
 Protocols die verwijzen naar dit protocol: bv SVP_xxx
 -->

--- a/inst/rmarkdown/templates/template_sfp_nl/skeleton/03_beperkingen.Rmd
+++ b/inst/rmarkdown/templates/template_sfp_nl/skeleton/03_beperkingen.Rmd
@@ -1,5 +1,6 @@
-## Beperkingen van het protocol (indien van toepassing)
+## Beperkingen van het protocol
 
 <!--
+Alleen in te vullen indien van toepassing.
 Bespreek onder welke condities het veldprotocol niet gebruikt kan worden of wanneer afwijkingen nodig zijn ten opzichte van het standaard protocol. Vermeld hier ook mogelijke interferenties, knelpunten, …
 -->

--- a/inst/rmarkdown/templates/template_sfp_nl/skeleton/03_beperkingen.Rmd
+++ b/inst/rmarkdown/templates/template_sfp_nl/skeleton/03_beperkingen.Rmd
@@ -1,5 +1,5 @@
 ## Beperkingen tot het protocol (indien van toepassing)
 
 <!--
-Bespreek hieronder onder welke condities het veldprotocol niet gebruikt kan worden of wanneer afwijkingen nodig zijn ten opzichte van het standaard protocol. Vermeld hier ook mogelijke interferenties, knelpunten, …
+Bespreek onder welke condities het veldprotocol niet gebruikt kan worden of wanneer afwijkingen nodig zijn ten opzichte van het standaard protocol. Vermeld hier ook mogelijke interferenties, knelpunten, …
 -->

--- a/inst/rmarkdown/templates/template_sfp_nl/skeleton/03_beperkingen.Rmd
+++ b/inst/rmarkdown/templates/template_sfp_nl/skeleton/03_beperkingen.Rmd
@@ -1,4 +1,4 @@
-## Beperkingen tot het protocol (indien van toepassing)
+## Beperkingen van het protocol (indien van toepassing)
 
 <!--
 Bespreek onder welke condities het veldprotocol niet gebruikt kan worden of wanneer afwijkingen nodig zijn ten opzichte van het standaard protocol. Vermeld hier ook mogelijke interferenties, knelpunten, …


### PR DESCRIPTION
While reviewing https://github.com/inbo/protocols/pull/26 I think the titles better don't carry "indien van toepassing". I suggest to leave empty by default (which may be the case for some other chapters, as well).

If you agree, it is still to be applied to the other templates, I guess.