### PR TITLE
update homepage created by render_release()

### DIFF
--- a/R/render_release.R
+++ b/R/render_release.R
@@ -67,7 +67,7 @@ render_release <- function(output_root = "publish") {
   wrong_format <- !grepl("[0-9]{4}\\.[0-9]{2}", version)
   if (any(wrong_format)) {
     stop(
-      "version not in YYYY-XX format: ",
+      "version not in YYYY.XX format: ",
       paste(protocol_index[wrong_format], collapse = "; ")
     )
   }


### PR DESCRIPTION
Currently, the `render_release()` function does not yet take into account project-specific protocols in the overview created in `homepage.html`.

I looked at the code but feel a little overwhelmed to try change this myself :thinking: 
@ThierryO I hope you can take a look at this... (and take this PR out if my hands)