### PR TITLE
update template (declare dependencies)

### DIFF
--- a/inst/rmarkdown/templates/template_sfp_en/skeleton/01_dependencies.Rmd
+++ b/inst/rmarkdown/templates/template_sfp_en/skeleton/01_dependencies.Rmd
@@ -1,7 +1,16 @@
 # Dependencies
 
 <!--
-Alleen in te vullen indien van toepassing.
-Protocols waarnaar in dit protocol verwezen wordt: <protocol-code>-YYYY.NN.
-Protocols die verwijzen naar dit protocol: <protocol-code>-YYYY.NN.
+Hier niets invullen.
+Indien er dependencies zijn deze invullen in de yaml sectie van index.Rmd
 -->
+
+
+```{r dependencies}
+dependencies <- as_tibble(params$dependencies_protocolcode) %>%
+  mutate(version_number = params$dependencies_versionnumber,
+         params = params$dependencies_params)
+
+dependencies %>%
+  kable()
+```

--- a/inst/rmarkdown/templates/template_sfp_en/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/template_sfp_en/skeleton/skeleton.Rmd
@@ -10,6 +10,9 @@ params:
   version_number: "{{{version_number}}}"
   language: {{{language}}}
   theme: {{{theme}}}
+  dependencies_protocolcode: [sfp_4##_en, sfp_3##_en]
+  dependencies_versionnumber: [YYYY.NN, YYYY.NN]
+  dependencies_params: !r list(list(width = 5, length = 5), list())
 site: bookdown::bookdown_site
 output: 
   bookdown::gitbook:
@@ -45,6 +48,7 @@ opts_chunk$set(
   error = TRUE,
   message = FALSE
 )
+library(tidyverse)
 ```
 
 # Metadata {-}


### PR DESCRIPTION
Proposal to declare dependencies via yaml params section.

I think this will make it easier to maintain dependencies among protocols and to add some or all dependencies as subprotocols in an appendix for project-specific protocols. For the latter, it may be a good idea to also add `dependencies_subprotocol: [TRUE, FALSE, ...]` to the yaml params section. If it is true, the corresponding dependency will be added entirely as a separate chapter (=subprotocol) in the appendix.

This is just an example. The idea is to make the same changes to all templates (sfp and spp), but I will wait for feedback first.

