### PR TITLE
Make Subtitle optional and other minor issues

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -35,5 +35,5 @@
       "orcid": "https://orcid.org/0000-0001-8595-8426"
     }
   ],
-  "language": "en"
+  "language": "en-GB"
 }

--- a/R/check_frontmatter.R
+++ b/R/check_frontmatter.R
@@ -38,7 +38,7 @@ check_frontmatter <- function(
 
   if (has_name(yml, "subtitle")) {
     assert_that(is.string(yml$subtitle),
-                msg = "Subtitle is not a string, maybe empty, please remove in the yaml header if not needed.")
+                msg = "Subtitle is not a string, maybe empty, please remove in the yaml header if not needed.") #nolint
   }
 
   assert_that(has_name(yml, "author"))

--- a/R/check_frontmatter.R
+++ b/R/check_frontmatter.R
@@ -37,7 +37,8 @@ check_frontmatter <- function(
   assert_that(is.string(yml$title))
 
   if (has_name(yml, "subtitle")) {
-    assert_that(is.string(yml$subtitle))
+    assert_that(is.string(yml$subtitle),
+                msg = "Subtitle is not a string, maybe empty, please remove in the yaml header if not needed.")
   }
 
   assert_that(has_name(yml, "author"))

--- a/R/create_protocol.R
+++ b/R/create_protocol.R
@@ -91,7 +91,7 @@
 create_protocol <- function(
   protocol_type = c("sfp", "spp"),
   title,
-  subtitle,
+  subtitle = NULL,
   short_title,
   authors,
   orcids,
@@ -109,7 +109,9 @@ create_protocol <- function(
   # check parameters
   protocol_type <- match.arg(protocol_type)
   assert_that(is.string(title))
-  assert_that(is.string(subtitle))
+  if (!is.null(subtitle)) {
+    assert_that(is.string(subtitle))
+  }
   assert_that(is.string(short_title), nchar(short_title) <= 20)
   assert_that(is.date(as.Date(date)))
   assert_that(is.character(authors))
@@ -254,6 +256,9 @@ create_protocol <- function(
     protocol_code = protocol_code,
     language = language
     )
+  if (is.null(subtitle)) {
+    index_yml <- ymlthis::yml_discard(index_yml, "subtitle")
+  }
   index_yml <- ymlthis::yml_author(
     index_yml,
     name = authors,

--- a/R/create_protocol.R
+++ b/R/create_protocol.R
@@ -41,8 +41,6 @@
 #' @inheritParams create_protocol_code
 #' @param title A character string giving the main title of the protocol
 #' @param subtitle A character string for an optional subtitle
-#' @param short_title A character string of less than 20 characters to use in
-#' folder and filenames
 #' @param authors A character vector for authors of the form First name Last
 #' name
 #' @param orcids A character vector of orcid IDs, equal in length to authors.
@@ -64,6 +62,8 @@
 #' the same project will be stored. Preferably a short name or acronym. If the
 #' folder does not exist, it will be created.
 #' Ignored if protocol_type = `"sfp"`.
+#' @param short_title A character string of less than 20 characters to use in
+#' folder and filenames
 #' @param from_docx A character string with the path (absolute or relative) to
 #' a `.docx` file containing a pre-existing protocol.
 #' Please make sure to copy-paste all relevant meta-data from the `.docx` file
@@ -91,7 +91,6 @@
 create_protocol <- function(
   protocol_type = c("sfp", "spp"),
   title,
-  subtitle = NULL,
   short_title,
   authors,
   orcids,
@@ -102,6 +101,7 @@ create_protocol <- function(
   theme = c("generic", "water", "air", "soil", "vegetation", "species"),
   project_name,
   language = c("nl", "en"),
+  subtitle = NULL,
   from_docx = NULL,
   protocol_number = NULL,
   render = FALSE) {

--- a/man/create_protocol.Rd
+++ b/man/create_protocol.Rd
@@ -10,7 +10,7 @@ protocol and optionally render to html}
 create_protocol(
   protocol_type = c("sfp", "spp"),
   title,
-  subtitle,
+  subtitle = NULL,
   short_title,
   authors,
   orcids,


### PR DESCRIPTION
This PR fixes issue #59 to make subtitle optional by:
- making this argument optional in `create_protocol()` and
- making the error message more informative in `check_frontmatter()`

It seems `render_release()` is not affected by the omission of subtitle, so I didn't change that.

I noticed .zenodo.json had to be updated, but I guess the current update is not compatible with the new version of checklist that will be released shortly: the language should be 'eng' instead of 'en_GB' (to not cause errors in Zenodo).