### PR TITLE
check for files that shouldn't be in the protocol

### DIFF
--- a/R/check_structure.R
+++ b/R/check_structure.R
@@ -97,25 +97,26 @@ check_structure <- function(protocol_code, fail = !interactive()) {
 
 check_file <- function(filename, x, files_template, path_to_template) {
   # check if file is present in template
-  if (!filename %in% c(files_template, "index.Rmd") &&
-      grepl("^\\d{2}_", filename)) {
-    x$add_error(
-      msg = sprintf("file %s should be removed (after moving the content)",
-                    filename))
-  }
+  x$add_error(
+    msg =
+      sprintf(
+        "file %s should be removed (after moving the content)",
+        filename[!filename %in% c(files_template, "index.Rmd") &&
+                   grepl("^\\d{2}_", filename)]
+      )
+  )
 
   # check if chunks in Rmd files are correct
   rmd <- readLines(file.path(x$path, filename))
   start_chunk <- grep("^```\\{r.*}", rmd)
   end_chunk <- grep("^```[:space:]?$", rmd)
-  if (
-    !(length(start_chunk) == length(end_chunk) &&
-      all(start_chunk < end_chunk))
-  ) {
-    x$add_error(
-      msg =
-        paste(", file", filename, "has a problem with R chunks"))
-  }
+  x$add_error(
+    msg =
+      paste(", file", filename, "has a problem with R chunks")[
+        !(length(start_chunk) == length(end_chunk) &&
+            all(start_chunk < end_chunk))
+      ]
+  )
 
   for (i in rev(seq_along(start_chunk))) {
     rmd <- c(
@@ -178,7 +179,7 @@ check_file <- function(filename, x, files_template, path_to_template) {
     }
 
   } else {
-    if (!grepl("^\\d{2}_", filename)) {
+    if (!grepl("^\\d{2}_", filename) && filename != "index.Rmd") {
       headings1 <- headings[grepl("^# .*", headings)]
       x$add_error(
         msg = sprintf(

--- a/R/check_structure.R
+++ b/R/check_structure.R
@@ -97,11 +97,11 @@ check_structure <- function(protocol_code, fail = !interactive()) {
 
 check_file <- function(filename, x, files_template, path_to_template) {
   # check if file is present in template
-  if (!filename %in% c(files_template, "index.Rmd")) {
+  if (!filename %in% c(files_template, "index.Rmd") &&
+      grepl("^\\d{2}_", filename)) {
     x$add_error(
       msg = sprintf("file %s should be removed (after moving the content)",
                     filename))
-    return(x)
   }
 
   # check if chunks in Rmd files are correct
@@ -177,6 +177,17 @@ check_file <- function(filename, x, files_template, path_to_template) {
       )
     }
 
+  } else {
+    if (!grepl("^\\d{2}_", filename)) {
+      headings1 <- headings[grepl("^# .*", headings)]
+      x$add_error(
+        msg = sprintf(
+          paste(filename,
+            "should not have headings of level 1, please adapt header(s): %s"),
+          headings1
+        )
+      )
+    }
   }
   if (filename == "index.Rmd") {
     template <- readLines(file.path(path_to_template, "skeleton.Rmd"))

--- a/R/check_structure.R
+++ b/R/check_structure.R
@@ -96,6 +96,14 @@ check_structure <- function(protocol_code, fail = !interactive()) {
 
 
 check_file <- function(filename, x, files_template, path_to_template) {
+  # check if file is present in template
+  if (!filename %in% c(files_template, "index.Rmd")) {
+    x$add_error(
+      msg = sprintf("file %s should be removed (after moving the content)",
+                    filename))
+    return(x)
+  }
+
   # check if chunks in Rmd files are correct
   rmd <- readLines(file.path(x$path, filename))
   start_chunk <- grep("^```\\{r.*}", rmd)


### PR DESCRIPTION
Adds the test that I promised in PR #71.

By adding this test, `check_structure()` adds an error when `.Rmd` files (chapters) in the protocol have a name that is not in the template: `file xxx should be removed (after moving the content)`.  With the existing error `the protocol lacks file(s) xxx`, users also get an overview of files that should be added, which together makes it easy to rename the incorrectly named files.

An example output:
```
> check_structure("sfp-001-nl")
Errors in protocol sfp-001-nl:
- the protocol lacks file(s) 04_principe.Rmd
- the protocol lacks file(s) 05_competenties.Rmd
- the protocol lacks file(s) 06_benodigdheden.Rmd
- the protocol lacks file(s) 07_werkwijze.Rmd
- Headings of file 02_onderwerp.Rmd are not in this order: # Onderwerp > ## Definities en afkortingen > ## Doelstelling en toepassingsgebied
- Heading(s) # Beperkingen van het protocol lack(s) in file 03_beperkingen.Rmd
- file 04_princiepe.Rmd should be removed (after moving the content)
- file 05_vaardigheden.Rmd should be removed (after moving the content)
- file 06_materialen.Rmd should be removed (after moving the content)
- file 07_stappenplan.Rmd should be removed (after moving the content)
```