### PR TITLE
V0.4.6

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "protocolhelper: Helper Functions to Manage Protocols",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Helper functions to manage INBO protocols.",
   "creators": [
     {

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,7 +17,7 @@ contact:
 - email: info@inbo.be
   name: Research Institute for Nature and Forest
 title: 'protocolhelper: Helper Functions to Manage Protocols'
-version: 0.4.5
+version: 0.4.6
 abstract: Helper functions to manage INBO protocols.
 license: GPL-3.0
 type: software

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: protocolhelper
 Title: Helper Functions to Manage Protocols
-Version: 0.4.5
+Version: 0.4.6
 Authors@R: c(
     person("Hans", "Van Calster", , "hans.vancalster@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-8595-8426")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# protocolhelper 0.4.6
+
+## Bug fixes
+
+* fixes a problem in `check_structure` when a subprotocol is present
+
 # protocolhelper 0.4.5
 
 ## Minor changes

--- a/R/check_structure.R
+++ b/R/check_structure.R
@@ -53,8 +53,10 @@ check_structure <- function(protocol_code, fail = !interactive()) {
       package = "protocolhelper")
   files_protocol <- dir_ls(x$path, recurse = TRUE, type = "file",
                            regexp = "css", invert = TRUE)
+  files_protocol <- path_rel(files_protocol, x$path)
   files_template <- dir_ls(path_to_template, recurse = TRUE, type = "file",
                            regexp = "css", invert = TRUE)
+  files_template <- path_rel(files_template, path_to_template)
 
   # check if file(name)s from template are conserved
   files_template_i <-

--- a/R/check_structure.R
+++ b/R/check_structure.R
@@ -17,6 +17,7 @@
 #' @importFrom utils head tail
 #' @importFrom assertthat assert_that is.flag noNA
 #' @importFrom stringr str_detect
+#' @importFrom fs dir_ls
 #'
 #' @export
 #'
@@ -50,8 +51,10 @@ check_structure <- function(protocol_code, fail = !interactive()) {
     system.file(
       file.path("rmarkdown", "templates", template_name, "skeleton"),
       package = "protocolhelper")
-  files_protocol <- list.files(path = x$path)
-  files_template <- list.files(path = path_to_template)
+  files_protocol <- dir_ls(x$path, recurse = TRUE, type = "file",
+                           regexp = "css", invert = TRUE)
+  files_template <- dir_ls(path_to_template, recurse = TRUE, type = "file",
+                           regexp = "css", invert = TRUE)
 
   # check if file(name)s from template are conserved
   files_template_i <-

--- a/R/check_structure.R
+++ b/R/check_structure.R
@@ -17,7 +17,7 @@
 #' @importFrom utils head tail
 #' @importFrom assertthat assert_that is.flag noNA
 #' @importFrom stringr str_detect
-#' @importFrom fs dir_ls
+#' @importFrom fs dir_ls path_rel
 #'
 #' @export
 #'

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -2,12 +2,12 @@ citHeader("To cite `protocolhelper` in publications please use:")
 # begin checklist entry
 citEntry(
   entry = "Manual",
-  title = "protocolhelper: Helper Functions to Manage Protocols. Version 0.4.5",
+  title = "protocolhelper: Helper Functions to Manage Protocols. Version 0.4.6",
   author = c(person(given = "Hans", family = "Van Calster"), person(given = "Thierry", family = "Onkelinx"), person(given = "Floris", family = "Vanderhaeghe")),
   year = 2022,
   url = "https://inbo.github.io/protocolhelper/",
   abstract = "Helper functions to manage INBO protocols.",
-  textVersion = "Van Calster, Hans; Onkelinx, Thierry; Vanderhaeghe, Floris (2022) protocolhelper: Helper Functions to Manage Protocols. Version 0.4.5. https://inbo.github.io/protocolhelper/, https://github.com/inbo/protocolhelper",
+  textVersion = "Van Calster, Hans; Onkelinx, Thierry; Vanderhaeghe, Floris (2022) protocolhelper: Helper Functions to Manage Protocols. Version 0.4.6. https://inbo.github.io/protocolhelper/, https://github.com/inbo/protocolhelper",
   keywords = "Protocols, R package, Reproducible research, Rmarkdown templates",
 )
 # end checklist entry


### PR DESCRIPTION
There was a problem with check_structure() when testing if all reference (.bib, .yaml,...) files that are listed in bibliography field are present. bib files for a subprotocol are in a subfolder, so recursion was needed to list these files.